### PR TITLE
German translation

### DIFF
--- a/src/argparse-de.po
+++ b/src/argparse-de.po
@@ -1,4 +1,4 @@
-# French translations for argparse module.
+# German translations for argparse module (Python release 3.11.2).
 # Copyright (C) 2018 s-ball
 # This file is distributed under the same license as the i18nparse package.
 # s-ball <s-ball@laposte.net>, 2018.
@@ -7,162 +7,176 @@ msgid ""
 msgstr ""
 "Project-Id-Version: i18nparse\n"
 "Report-Msgid-Bugs-To: s-ball@laposte.net\n"
-"POT-Creation-Date: 2018-12-06 12:07+0100\n"
-"PO-Revision-Date: 2023-03-23 13:41+0100\n"
+"POT-Creation-Date: 2023-03-23 14:43+0100\n"
+"PO-Revision-Date: 2023-03-23 15:46+0100\n"
 "Last-Translator: blackstream-x <rz498sc@gmx.net>\n"
 "Language-Team: German\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.2.2\n"
 
-#: ../../cpython/Lib/argparse.py:294
+#: argparse.py:299
 msgid "usage: "
 msgstr "Aufruf: "
 
-#: ../../cpython/Lib/argparse.py:836
+#: argparse.py:769
+#, python-format
+msgid "argument %(argument_name)s: %(message)s"
+msgstr "Parameter %(argument_name)s: %(message)s"
+
+#: argparse.py:875
 msgid ".__call__() not defined"
 msgstr ".__call__() ist undefiniert"
 
-#: ../../cpython/Lib/argparse.py:1139
+#: argparse.py:1185
+#, python-format
+msgid "conflicting subparser: %s"
+msgstr "Subparser im Konflikt: %s"
+
+#: argparse.py:1189
+#, python-format
+msgid "conflicting subparser alias: %s"
+msgstr "Subparser-Alias im Konflikt: %s"
+
+#: argparse.py:1224
 #, python-format
 msgid "unknown parser %(parser_name)r (choices: %(choices)s)"
-msgstr "unbekannter Parser %(parser_name)r (Auswahl: %(choices)s"
+msgstr "unbekannter Parser %(parser_name)r (Auswahl aus %(choices)s)"
 
-#: ../../cpython/Lib/argparse.py:1193
+#: argparse.py:1284
 #, python-format
 msgid "argument \"-\" with mode %r"
-msgstr "Argument \"-\" mit Zugriffsart %r"
+msgstr "Parameter \"-\" mit Zugriffsart %r"
 
-#: ../../cpython/Lib/argparse.py:1201
+#: argparse.py:1293
 #, python-format
-msgid "can't open '%s': %s"
-msgstr "kann '%s' nicht öffnen: %s"
+msgid "can't open '%(filename)s': %(error)s"
+msgstr "kann '%(filename)s' nicht öffnen: %(error)s"
 
-#: ../../cpython/Lib/argparse.py:1405
+#: argparse.py:1502
 #, python-format
 msgid "cannot merge actions - two groups are named %r"
-msgstr "kann Aktionen nicht zusammenführen - zwei Gruppen mit gleichem Namen %r"
+msgstr "kann Aktionen nicht zusammenführen - zwei Gruppen haben den gleichen Namen %r"
 
-#: ../../cpython/Lib/argparse.py:1443
+#: argparse.py:1540
 msgid "'required' is an invalid argument for positionals"
-msgstr "'required' kann bei Positionsparametern nicht verwendet werden"
+msgstr "'required' ist in Verbindung mit Positionsparametern ungültig"
 
-#: ../../cpython/Lib/argparse.py:1465
+#: argparse.py:1562
 #, python-format
-msgid ""
-"invalid option string %(option)r: must start with a character "
-"%(prefix_chars)r"
-msgstr "Option  %(option)r ungültig: muss mit einem Zeichen %(prefix_chars)r beginnen"
+msgid "invalid option string %(option)r: must start with a character %(prefix_chars)r"
+msgstr "Option %(option)r ungültig: muss mit einem Zeichen %(prefix_chars)r beginnen"
 
-#: ../../cpython/Lib/argparse.py:1485
+#: argparse.py:1580
 #, python-format
 msgid "dest= is required for options like %r"
 msgstr "dest= wird bei Optionen wie %r benötigt"
 
-#: ../../cpython/Lib/argparse.py:1502
+#: argparse.py:1597
 #, python-format
 msgid "invalid conflict_resolution value: %r"
 msgstr "ungültiger Wert für conflict_resolution: %r"
 
-#: ../../cpython/Lib/argparse.py:1520
+#: argparse.py:1615
 #, python-format
 msgid "conflicting option string: %s"
 msgid_plural "conflicting option strings: %s"
 msgstr[0] "Option steht im Konflikt: %s"
 msgstr[1] "Optionen stehen im Konflikt: %s"
 
-#: ../../cpython/Lib/argparse.py:1586
+#: argparse.py:1689
 msgid "mutually exclusive arguments must be optional"
-msgstr "sich gegenseitig ausschließende Option müssen optional sein"
+msgstr "sich gegenseitig ausschließende Parameter müssen optional sein"
 
-#: ../../cpython/Lib/argparse.py:1649
+#: argparse.py:1765
 msgid "positional arguments"
 msgstr "Positionsparameter"
 
-#: ../../cpython/Lib/argparse.py:1650
-msgid "optional arguments"
-msgstr "optionale Parameter"
+#: argparse.py:1766
+msgid "options"
+msgstr "Optionen"
 
-#: ../../cpython/Lib/argparse.py:1665
+#: argparse.py:1781
 msgid "show this help message and exit"
 msgstr "diese Meldung anzeigen und beenden"
 
-#: ../../cpython/Lib/argparse.py:1696
+#: argparse.py:1812
 msgid "cannot have multiple subparser arguments"
-msgstr "mehrfache Subparser-Argumente werden nicht unterstützt"
+msgstr "mehrfache Subparser werden nicht unterstützt"
 
-#: ../../cpython/Lib/argparse.py:1748 ../../cpython/Lib/argparse.py:2254
+#: argparse.py:1864 argparse.py:2377
 #, python-format
 msgid "unrecognized arguments: %s"
 msgstr "Parameter nicht erkannt: %s"
 
-#: ../../cpython/Lib/argparse.py:1845
+#: argparse.py:1964
 #, python-format
 msgid "not allowed with argument %s"
-msgstr "in Verbindung mit %s nicht erlaubt"
+msgstr "in Verbindung mit Parameter %s nicht erlaubt"
 
-#: ../../cpython/Lib/argparse.py:1891 ../../cpython/Lib/argparse.py:1905
+#: argparse.py:2014 argparse.py:2028
 #, python-format
 msgid "ignored explicit argument %r"
 msgstr "expliziten Parameter %r ignoriert"
 
-#: ../../cpython/Lib/argparse.py:2012
+#: argparse.py:2135
 #, python-format
 msgid "the following arguments are required: %s"
 msgstr "die folgenden Parameter werden benötigt: %s"
 
-#: ../../cpython/Lib/argparse.py:2027
+#: argparse.py:2150
 #, python-format
 msgid "one of the arguments %s is required"
 msgstr "einer der Parameter %s wird benötigt"
 
-#: ../../cpython/Lib/argparse.py:2070
+#: argparse.py:2192
 msgid "expected one argument"
 msgstr "genau ein Parameter wird erwartet"
 
-#: ../../cpython/Lib/argparse.py:2071
+#: argparse.py:2193
 msgid "expected at most one argument"
 msgstr "höchstens ein Parameter wird erwartet"
 
-#: ../../cpython/Lib/argparse.py:2072
+#: argparse.py:2194
 msgid "expected at least one argument"
 msgstr "mindestens ein Parameter wird erwartet"
 
-#: ../../cpython/Lib/argparse.py:2074
+#: argparse.py:2198
 #, python-format
 msgid "expected %s argument"
 msgid_plural "expected %s arguments"
 msgstr[0] "%s Parameter wird erwartet"
 msgstr[1] "%s Parameter werden erwartet"
 
-#: ../../cpython/Lib/argparse.py:2134
+#: argparse.py:2256
 #, python-format
 msgid "ambiguous option: %(option)s could match %(matches)s"
 msgstr "Option nicht eindeutig: %(option)s passt auf %(matches)s"
 
-#: ../../cpython/Lib/argparse.py:2197
+#: argparse.py:2320
 #, python-format
 msgid "unexpected option string: %s"
 msgstr "unerwartete Option: %s"
 
-#: ../../cpython/Lib/argparse.py:2394
+#: argparse.py:2517
 #, python-format
 msgid "%r is not callable"
 msgstr "%r ist nicht aufrufbar"
 
-#: ../../cpython/Lib/argparse.py:2411
+#: argparse.py:2534
 #, python-format
 msgid "invalid %(type)s value: %(value)r"
-msgstr "ungültiger Wert %(value)r für %(type)s"
+msgstr "ungültiger Wert für %(type)s: %(value)r"
 
-#: ../../cpython/Lib/argparse.py:2422
+#: argparse.py:2545
 #, python-format
 msgid "invalid choice: %(value)r (choose from %(choices)s)"
-msgstr "ungültige Auswahl: %(value)r (eine von %(choices)s)"
+msgstr "ungültige Wahl: %(value)r (Auswahl aus %(choices)s)"
 
-#: ../../cpython/Lib/argparse.py:2498
+#: argparse.py:2621
 #, python-format
 msgid "%(prog)s: error: %(message)s\n"
 msgstr "%(prog)s: Fehler: %(message)s\n"

--- a/src/argparse-de.po
+++ b/src/argparse-de.po
@@ -1,0 +1,168 @@
+# French translations for argparse module.
+# Copyright (C) 2018 s-ball
+# This file is distributed under the same license as the i18nparse package.
+# s-ball <s-ball@laposte.net>, 2018.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: i18nparse\n"
+"Report-Msgid-Bugs-To: s-ball@laposte.net\n"
+"POT-Creation-Date: 2018-12-06 12:07+0100\n"
+"PO-Revision-Date: 2023-03-23 13:41+0100\n"
+"Last-Translator: blackstream-x <rz498sc@gmx.net>\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: ../../cpython/Lib/argparse.py:294
+msgid "usage: "
+msgstr "Aufruf: "
+
+#: ../../cpython/Lib/argparse.py:836
+msgid ".__call__() not defined"
+msgstr ".__call__() ist undefiniert"
+
+#: ../../cpython/Lib/argparse.py:1139
+#, python-format
+msgid "unknown parser %(parser_name)r (choices: %(choices)s)"
+msgstr "unbekannter Parser %(parser_name)r (Auswahl: %(choices)s"
+
+#: ../../cpython/Lib/argparse.py:1193
+#, python-format
+msgid "argument \"-\" with mode %r"
+msgstr "Argument \"-\" mit Zugriffsart %r"
+
+#: ../../cpython/Lib/argparse.py:1201
+#, python-format
+msgid "can't open '%s': %s"
+msgstr "kann '%s' nicht öffnen: %s"
+
+#: ../../cpython/Lib/argparse.py:1405
+#, python-format
+msgid "cannot merge actions - two groups are named %r"
+msgstr "kann Aktionen nicht zusammenführen - zwei Gruppen mit gleichem Namen %r"
+
+#: ../../cpython/Lib/argparse.py:1443
+msgid "'required' is an invalid argument for positionals"
+msgstr "'required' kann bei Positionsparametern nicht verwendet werden"
+
+#: ../../cpython/Lib/argparse.py:1465
+#, python-format
+msgid ""
+"invalid option string %(option)r: must start with a character "
+"%(prefix_chars)r"
+msgstr "Option  %(option)r ungültig: muss mit einem Zeichen %(prefix_chars)r beginnen"
+
+#: ../../cpython/Lib/argparse.py:1485
+#, python-format
+msgid "dest= is required for options like %r"
+msgstr "dest= wird bei Optionen wie %r benötigt"
+
+#: ../../cpython/Lib/argparse.py:1502
+#, python-format
+msgid "invalid conflict_resolution value: %r"
+msgstr "ungültiger Wert für conflict_resolution: %r"
+
+#: ../../cpython/Lib/argparse.py:1520
+#, python-format
+msgid "conflicting option string: %s"
+msgid_plural "conflicting option strings: %s"
+msgstr[0] "Option steht im Konflikt: %s"
+msgstr[1] "Optionen stehen im Konflikt: %s"
+
+#: ../../cpython/Lib/argparse.py:1586
+msgid "mutually exclusive arguments must be optional"
+msgstr "sich gegenseitig ausschließende Option müssen optional sein"
+
+#: ../../cpython/Lib/argparse.py:1649
+msgid "positional arguments"
+msgstr "Positionsparameter"
+
+#: ../../cpython/Lib/argparse.py:1650
+msgid "optional arguments"
+msgstr "optionale Parameter"
+
+#: ../../cpython/Lib/argparse.py:1665
+msgid "show this help message and exit"
+msgstr "diese Meldung anzeigen und beenden"
+
+#: ../../cpython/Lib/argparse.py:1696
+msgid "cannot have multiple subparser arguments"
+msgstr "mehrfache Subparser-Argumente werden nicht unterstützt"
+
+#: ../../cpython/Lib/argparse.py:1748 ../../cpython/Lib/argparse.py:2254
+#, python-format
+msgid "unrecognized arguments: %s"
+msgstr "Parameter nicht erkannt: %s"
+
+#: ../../cpython/Lib/argparse.py:1845
+#, python-format
+msgid "not allowed with argument %s"
+msgstr "in Verbindung mit %s nicht erlaubt"
+
+#: ../../cpython/Lib/argparse.py:1891 ../../cpython/Lib/argparse.py:1905
+#, python-format
+msgid "ignored explicit argument %r"
+msgstr "expliziten Parameter %r ignoriert"
+
+#: ../../cpython/Lib/argparse.py:2012
+#, python-format
+msgid "the following arguments are required: %s"
+msgstr "die folgenden Parameter werden benötigt: %s"
+
+#: ../../cpython/Lib/argparse.py:2027
+#, python-format
+msgid "one of the arguments %s is required"
+msgstr "einer der Parameter %s wird benötigt"
+
+#: ../../cpython/Lib/argparse.py:2070
+msgid "expected one argument"
+msgstr "genau ein Parameter wird erwartet"
+
+#: ../../cpython/Lib/argparse.py:2071
+msgid "expected at most one argument"
+msgstr "höchstens ein Parameter wird erwartet"
+
+#: ../../cpython/Lib/argparse.py:2072
+msgid "expected at least one argument"
+msgstr "mindestens ein Parameter wird erwartet"
+
+#: ../../cpython/Lib/argparse.py:2074
+#, python-format
+msgid "expected %s argument"
+msgid_plural "expected %s arguments"
+msgstr[0] "%s Parameter wird erwartet"
+msgstr[1] "%s Parameter werden erwartet"
+
+#: ../../cpython/Lib/argparse.py:2134
+#, python-format
+msgid "ambiguous option: %(option)s could match %(matches)s"
+msgstr "Option nicht eindeutig: %(option)s passt auf %(matches)s"
+
+#: ../../cpython/Lib/argparse.py:2197
+#, python-format
+msgid "unexpected option string: %s"
+msgstr "unerwartete Option: %s"
+
+#: ../../cpython/Lib/argparse.py:2394
+#, python-format
+msgid "%r is not callable"
+msgstr "%r ist nicht aufrufbar"
+
+#: ../../cpython/Lib/argparse.py:2411
+#, python-format
+msgid "invalid %(type)s value: %(value)r"
+msgstr "ungültiger Wert %(value)r für %(type)s"
+
+#: ../../cpython/Lib/argparse.py:2422
+#, python-format
+msgid "invalid choice: %(value)r (choose from %(choices)s)"
+msgstr "ungültige Auswahl: %(value)r (eine von %(choices)s)"
+
+#: ../../cpython/Lib/argparse.py:2498
+#, python-format
+msgid "%(prog)s: error: %(message)s\n"
+msgstr "%(prog)s: Fehler: %(message)s\n"


### PR DESCRIPTION
Hello!

I learned about this project [via Stack Overflow](https://stackoverflow.com/a/53203187), and it inspired me to try gettext and poedit.

This is my attempt at a german argparse translation, based on [Python 3.11.2](https://github.com/python/cpython/tree/v3.11.2). Most of the messages should work with oder Python versions as well.

I have tested the translation in a small german-language project (https://codeberg.org/blackstream-x/postleid) where I incorporated a part of your module. 

It would be a pleasure if you could have a look at my contribution.

Thank you for your great work!

Kind regards
Rainer 