### PR TITLE
Updated german translations including latest 3.8 through 3.13 releases

### DIFF
--- a/src/argparse-de.po
+++ b/src/argparse-de.po
@@ -1,4 +1,4 @@
-# German translations for argparse module (Python release 3.11.2).
+# German translations for argparse module (Python releases 3.8 - 3.13 as of 2023-10-31).
 # Copyright (C) 2018 s-ball
 # This file is distributed under the same license as the i18nparse package.
 # s-ball <s-ball@laposte.net>, 2018.
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: i18nparse\n"
 "Report-Msgid-Bugs-To: s-ball@laposte.net\n"
-"POT-Creation-Date: 2023-03-23 14:43+0100\n"
-"PO-Revision-Date: 2023-03-23 15:46+0100\n"
+"POT-Creation-Date: 2023-10-31 08:29+0100\n"
+"PO-Revision-Date: 2023-10-31 08:38+0100\n"
 "Last-Translator: blackstream-x <rz498sc@gmx.net>\n"
 "Language-Team: German\n"
 "Language: de\n"
@@ -16,167 +16,219 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.4\n"
+"X-Poedit-Basepath: .\n"
+"X-Poedit-SearchPath-0: v3.8.18\n"
+"X-Poedit-SearchPath-1: v3.9.18\n"
+"X-Poedit-SearchPath-2: v3.10.13\n"
+"X-Poedit-SearchPath-3: v3.11.6\n"
+"X-Poedit-SearchPath-4: v3.12.0\n"
+"X-Poedit-SearchPath-5: v3.13.0a1\n"
 
-#: argparse.py:299
+#: v3.10.13/argparse.py:296 v3.11.6/argparse.py:299 v3.12.0/argparse.py:299
+#: v3.13.0a1/argparse.py:297 v3.8.18/argparse.py:295 v3.9.18/argparse.py:296
 msgid "usage: "
 msgstr "Aufruf: "
 
-#: argparse.py:769
-#, python-format
-msgid "argument %(argument_name)s: %(message)s"
-msgstr "Parameter %(argument_name)s: %(message)s"
-
-#: argparse.py:875
+#: v3.10.13/argparse.py:868 v3.11.6/argparse.py:882 v3.12.0/argparse.py:883
+#: v3.13.0a1/argparse.py:881 v3.8.18/argparse.py:846 v3.9.18/argparse.py:861
 msgid ".__call__() not defined"
 msgstr ".__call__() ist undefiniert"
 
-#: argparse.py:1185
-#, python-format
-msgid "conflicting subparser: %s"
-msgstr "Subparser im Konflikt: %s"
-
-#: argparse.py:1189
-#, python-format
-msgid "conflicting subparser alias: %s"
-msgstr "Subparser-Alias im Konflikt: %s"
-
-#: argparse.py:1224
+#: v3.10.13/argparse.py:1211 v3.11.6/argparse.py:1231 v3.12.0/argparse.py:1253
+#: v3.13.0a1/argparse.py:1252 v3.8.18/argparse.py:1149 v3.9.18/argparse.py:1204
 #, python-format
 msgid "unknown parser %(parser_name)r (choices: %(choices)s)"
 msgstr "unbekannter Parser %(parser_name)r (Auswahl aus %(choices)s)"
 
-#: argparse.py:1284
+#: v3.10.13/argparse.py:1271 v3.11.6/argparse.py:1291 v3.12.0/argparse.py:1313
+#: v3.13.0a1/argparse.py:1312 v3.8.18/argparse.py:1209 v3.9.18/argparse.py:1264
 #, python-format
 msgid "argument \"-\" with mode %r"
 msgstr "Parameter \"-\" mit Zugriffsart %r"
 
-#: argparse.py:1293
+#: v3.10.13/argparse.py:1280 v3.11.6/argparse.py:1300 v3.12.0/argparse.py:1322
+#: v3.13.0a1/argparse.py:1321 v3.8.18/argparse.py:1218 v3.9.18/argparse.py:1273
 #, python-format
 msgid "can't open '%(filename)s': %(error)s"
 msgstr "kann '%(filename)s' nicht öffnen: %(error)s"
 
-#: argparse.py:1502
+#: v3.10.13/argparse.py:1489 v3.11.6/argparse.py:1509 v3.12.0/argparse.py:1531
+#: v3.13.0a1/argparse.py:1532 v3.8.18/argparse.py:1427 v3.9.18/argparse.py:1482
 #, python-format
 msgid "cannot merge actions - two groups are named %r"
-msgstr "kann Aktionen nicht zusammenführen - zwei Gruppen haben den gleichen Namen %r"
+msgstr ""
+"kann Aktionen nicht zusammenführen - zwei Gruppen haben den gleichen Namen %r"
 
-#: argparse.py:1540
+#: v3.10.13/argparse.py:1527 v3.11.6/argparse.py:1547 v3.12.0/argparse.py:1569
+#: v3.13.0a1/argparse.py:1570 v3.8.18/argparse.py:1465 v3.9.18/argparse.py:1520
 msgid "'required' is an invalid argument for positionals"
-msgstr "'required' ist in Verbindung mit Positionsparametern ungültig"
+msgstr "'required' darf nicht mit Positionsparametern verwendet werden"
 
-#: argparse.py:1562
+#: v3.10.13/argparse.py:1549 v3.11.6/argparse.py:1569 v3.12.0/argparse.py:1591
+#: v3.13.0a1/argparse.py:1592 v3.8.18/argparse.py:1487 v3.9.18/argparse.py:1542
 #, python-format
-msgid "invalid option string %(option)r: must start with a character %(prefix_chars)r"
-msgstr "Option %(option)r ungültig: muss mit einem Zeichen %(prefix_chars)r beginnen"
+msgid ""
+"invalid option string %(option)r: must start with a character "
+"%(prefix_chars)r"
+msgstr ""
+"Option %(option)r ungültig: muss mit einem Zeichen %(prefix_chars)r beginnen"
 
-#: argparse.py:1580
+#: v3.10.13/argparse.py:1567 v3.11.6/argparse.py:1587 v3.12.0/argparse.py:1609
+#: v3.13.0a1/argparse.py:1610 v3.8.18/argparse.py:1507 v3.9.18/argparse.py:1560
 #, python-format
 msgid "dest= is required for options like %r"
 msgstr "dest= wird bei Optionen wie %r benötigt"
 
-#: argparse.py:1597
+#: v3.10.13/argparse.py:1584 v3.11.6/argparse.py:1604 v3.12.0/argparse.py:1626
+#: v3.13.0a1/argparse.py:1627 v3.8.18/argparse.py:1524 v3.9.18/argparse.py:1577
 #, python-format
 msgid "invalid conflict_resolution value: %r"
 msgstr "ungültiger Wert für conflict_resolution: %r"
 
-#: argparse.py:1615
+#: v3.10.13/argparse.py:1602 v3.11.6/argparse.py:1622 v3.12.0/argparse.py:1644
+#: v3.13.0a1/argparse.py:1645 v3.8.18/argparse.py:1542 v3.9.18/argparse.py:1595
 #, python-format
 msgid "conflicting option string: %s"
 msgid_plural "conflicting option strings: %s"
 msgstr[0] "Option steht im Konflikt: %s"
 msgstr[1] "Optionen stehen im Konflikt: %s"
 
-#: argparse.py:1689
+#: v3.10.13/argparse.py:1668 v3.11.6/argparse.py:1696 v3.12.0/argparse.py:1718
+#: v3.13.0a1/argparse.py:1720 v3.8.18/argparse.py:1608 v3.9.18/argparse.py:1661
 msgid "mutually exclusive arguments must be optional"
 msgstr "sich gegenseitig ausschließende Parameter müssen optional sein"
 
-#: argparse.py:1765
+#: v3.10.13/argparse.py:1736 v3.11.6/argparse.py:1772 v3.12.0/argparse.py:1794
+#: v3.13.0a1/argparse.py:1797 v3.8.18/argparse.py:1671 v3.9.18/argparse.py:1728
 msgid "positional arguments"
 msgstr "Positionsparameter"
 
-#: argparse.py:1766
+#: v3.10.13/argparse.py:1737 v3.11.6/argparse.py:1773 v3.12.0/argparse.py:1795
+#: v3.13.0a1/argparse.py:1798
 msgid "options"
 msgstr "Optionen"
 
-#: argparse.py:1781
+#: v3.10.13/argparse.py:1752 v3.11.6/argparse.py:1788 v3.12.0/argparse.py:1810
+#: v3.13.0a1/argparse.py:1813 v3.8.18/argparse.py:1687 v3.9.18/argparse.py:1744
 msgid "show this help message and exit"
 msgstr "diese Meldung anzeigen und beenden"
 
-#: argparse.py:1812
+#: v3.10.13/argparse.py:1783 v3.11.6/argparse.py:1819 v3.12.0/argparse.py:1841
+#: v3.13.0a1/argparse.py:1842 v3.8.18/argparse.py:1718 v3.9.18/argparse.py:1775
 msgid "cannot have multiple subparser arguments"
 msgstr "mehrfache Subparser werden nicht unterstützt"
 
-#: argparse.py:1864 argparse.py:2377
+#: v3.10.13/argparse.py:1835 v3.10.13/argparse.py:2350 v3.11.6/argparse.py:1871
+#: v3.11.6/argparse.py:2384 v3.12.0/argparse.py:1893 v3.12.0/argparse.py:2408
+#: v3.13.0a1/argparse.py:1894 v3.13.0a1/argparse.py:2409
+#: v3.8.18/argparse.py:1770 v3.8.18/argparse.py:2277 v3.9.18/argparse.py:1827
+#: v3.9.18/argparse.py:2338
 #, python-format
 msgid "unrecognized arguments: %s"
 msgstr "Parameter nicht erkannt: %s"
 
-#: argparse.py:1964
+#: v3.10.13/argparse.py:1936 v3.11.6/argparse.py:1971 v3.12.0/argparse.py:1993
+#: v3.13.0a1/argparse.py:1994 v3.8.18/argparse.py:1867 v3.9.18/argparse.py:1928
 #, python-format
 msgid "not allowed with argument %s"
 msgstr "in Verbindung mit Parameter %s nicht erlaubt"
 
-#: argparse.py:2014 argparse.py:2028
+#: v3.10.13/argparse.py:1986 v3.10.13/argparse.py:2000 v3.11.6/argparse.py:2021
+#: v3.11.6/argparse.py:2035 v3.12.0/argparse.py:2043 v3.12.0/argparse.py:2057
+#: v3.13.0a1/argparse.py:2044 v3.13.0a1/argparse.py:2058
+#: v3.8.18/argparse.py:1913 v3.8.18/argparse.py:1927 v3.9.18/argparse.py:1974
+#: v3.9.18/argparse.py:1988
 #, python-format
 msgid "ignored explicit argument %r"
 msgstr "expliziten Parameter %r ignoriert"
 
-#: argparse.py:2135
+#: v3.10.13/argparse.py:2107 v3.11.6/argparse.py:2142 v3.12.0/argparse.py:2164
+#: v3.13.0a1/argparse.py:2165 v3.8.18/argparse.py:2034 v3.9.18/argparse.py:2095
 #, python-format
 msgid "the following arguments are required: %s"
 msgstr "die folgenden Parameter werden benötigt: %s"
 
-#: argparse.py:2150
+#: v3.10.13/argparse.py:2122 v3.11.6/argparse.py:2157 v3.12.0/argparse.py:2179
+#: v3.13.0a1/argparse.py:2180 v3.8.18/argparse.py:2049 v3.9.18/argparse.py:2110
 #, python-format
 msgid "one of the arguments %s is required"
 msgstr "einer der Parameter %s wird benötigt"
 
-#: argparse.py:2192
+#: v3.10.13/argparse.py:2165 v3.11.6/argparse.py:2199 v3.12.0/argparse.py:2223
+#: v3.13.0a1/argparse.py:2224 v3.8.18/argparse.py:2092 v3.9.18/argparse.py:2153
 msgid "expected one argument"
 msgstr "genau ein Parameter wird erwartet"
 
-#: argparse.py:2193
+#: v3.10.13/argparse.py:2166 v3.11.6/argparse.py:2200 v3.12.0/argparse.py:2224
+#: v3.13.0a1/argparse.py:2225 v3.8.18/argparse.py:2093 v3.9.18/argparse.py:2154
 msgid "expected at most one argument"
 msgstr "höchstens ein Parameter wird erwartet"
 
-#: argparse.py:2194
+#: v3.10.13/argparse.py:2167 v3.11.6/argparse.py:2201 v3.12.0/argparse.py:2225
+#: v3.13.0a1/argparse.py:2226 v3.8.18/argparse.py:2094 v3.9.18/argparse.py:2155
 msgid "expected at least one argument"
 msgstr "mindestens ein Parameter wird erwartet"
 
-#: argparse.py:2198
+#: v3.10.13/argparse.py:2171 v3.11.6/argparse.py:2205 v3.12.0/argparse.py:2229
+#: v3.13.0a1/argparse.py:2230 v3.8.18/argparse.py:2098 v3.9.18/argparse.py:2159
 #, python-format
 msgid "expected %s argument"
 msgid_plural "expected %s arguments"
 msgstr[0] "%s Parameter wird erwartet"
 msgstr[1] "%s Parameter werden erwartet"
 
-#: argparse.py:2256
+#: v3.10.13/argparse.py:2229 v3.11.6/argparse.py:2263 v3.12.0/argparse.py:2287
+#: v3.13.0a1/argparse.py:2288 v3.8.18/argparse.py:2156 v3.9.18/argparse.py:2217
 #, python-format
 msgid "ambiguous option: %(option)s could match %(matches)s"
 msgstr "Option nicht eindeutig: %(option)s passt auf %(matches)s"
 
-#: argparse.py:2320
+#: v3.10.13/argparse.py:2293 v3.11.6/argparse.py:2327 v3.12.0/argparse.py:2351
+#: v3.13.0a1/argparse.py:2352 v3.8.18/argparse.py:2220 v3.9.18/argparse.py:2281
 #, python-format
 msgid "unexpected option string: %s"
 msgstr "unerwartete Option: %s"
 
-#: argparse.py:2517
+#: v3.10.13/argparse.py:2490 v3.11.6/argparse.py:2524 v3.12.0/argparse.py:2550
+#: v3.13.0a1/argparse.py:2551 v3.8.18/argparse.py:2417 v3.9.18/argparse.py:2478
 #, python-format
 msgid "%r is not callable"
 msgstr "%r ist nicht aufrufbar"
 
-#: argparse.py:2534
+#: v3.10.13/argparse.py:2507 v3.11.6/argparse.py:2541 v3.12.0/argparse.py:2566
+#: v3.13.0a1/argparse.py:2567 v3.8.18/argparse.py:2434 v3.9.18/argparse.py:2495
 #, python-format
 msgid "invalid %(type)s value: %(value)r"
 msgstr "ungültiger Wert für %(type)s: %(value)r"
 
-#: argparse.py:2545
+#: v3.10.13/argparse.py:2518 v3.11.6/argparse.py:2552 v3.12.0/argparse.py:2577
+#: v3.13.0a1/argparse.py:2578 v3.8.18/argparse.py:2445 v3.9.18/argparse.py:2506
 #, python-format
 msgid "invalid choice: %(value)r (choose from %(choices)s)"
-msgstr "ungültige Wahl: %(value)r (Auswahl aus %(choices)s)"
+msgstr "ungültiger Wert: %(value)r (Auswahl aus %(choices)s)"
 
-#: argparse.py:2621
+#: v3.10.13/argparse.py:2594 v3.11.6/argparse.py:2630 v3.12.0/argparse.py:2655
+#: v3.13.0a1/argparse.py:2656 v3.8.18/argparse.py:2521 v3.9.18/argparse.py:2582
 #, python-format
 msgid "%(prog)s: error: %(message)s\n"
 msgstr "%(prog)s: Fehler: %(message)s\n"
+
+#: v3.11.6/argparse.py:776 v3.12.0/argparse.py:777 v3.13.0a1/argparse.py:775
+#, python-format
+msgid "argument %(argument_name)s: %(message)s"
+msgstr "Parameter %(argument_name)s: %(message)s"
+
+#: v3.11.6/argparse.py:1192 v3.12.0/argparse.py:1214 v3.13.0a1/argparse.py:1213
+#, python-format
+msgid "conflicting subparser: %s"
+msgstr "Subparser im Konflikt: %s"
+
+#: v3.11.6/argparse.py:1196 v3.12.0/argparse.py:1218 v3.13.0a1/argparse.py:1217
+#, python-format
+msgid "conflicting subparser alias: %s"
+msgstr "Subparser-Alias im Konflikt: %s"
+
+#: v3.8.18/argparse.py:1672 v3.9.18/argparse.py:1729
+msgid "optional arguments"
+msgstr "Optionen"


### PR DESCRIPTION
Hi s-ball,

here is my second attempt at a german translation, this time containing translations for the most current release of each Python major version between 3.8 and 3.13.

This translation includes one additional message (the missing translation of "optional arguments" in 3.8 and 3.9) as well as updated wording in two existing messages.

Kind regards
Rainer